### PR TITLE
CFIN-184 Revert to full URL path for the openAPI spec location

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
-      url: "../spec/openAPI.yml",
+      url: "https://raw.githubusercontent.com/university-of-york/uoy-config-funnelback-courses/master/spec/openAPI.yml",
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [


### PR DESCRIPTION
Having tried to make the local path work, I've reverted back to the full path for the openAPI.yml: https://raw.githubusercontent.com/university-of-york/uoy-config-funnelback-courses/master/spec/openAPI.yml

