### PR TITLE
Removes event related meta mappings

### DIFF
--- a/config/metamap.cfg
+++ b/config/metamap.cfg
@@ -123,14 +123,3 @@ courseLength,0,course.length
 courseUcasCode,1,course.ucasCode
 courseAward,0,course.award
 courseDistanceLearning,0,course.distanceLearning
-# Event-specific data
-eventTitle,1,eventTitle
-eventType,0,eventType
-eventTags,0,eventTags
-eventCategory,0,eventCategory
-eventAudience,0,eventAudience
-eventDate,0,eventDate
-eventTime,0,eventTime
-eventLocation,0,eventLocation
-
-


### PR DESCRIPTION
Removes the event related meta tag mappings in the config file that had been copied over from the main website search collection.