### PR TITLE
Sync: update kill_exact to match actual config on Funnelback

### DIFF
--- a/config/kill_exact.cfg
+++ b/config/kill_exact.cfg
@@ -1,2 +1,1 @@
 https://www.york.ac.uk/study/undergraduate/courses/all
-https://www.york.ac.uk/study/undergraduate/courses/teaching-learning/


### PR DESCRIPTION
Second line has been removed as using the smeta_contentType parameter to screen out non-course results. 