### PR TITLE
Align the Funnelback OpenAPI spec with actual behaviour

### DIFF
--- a/spec/openAPI.yml
+++ b/spec/openAPI.yml
@@ -98,7 +98,7 @@ components:
       properties:
         numberOfMatches:
           type: integer
-        courses:
+        results:
           type: array
           items:
             $ref: '#/components/schemas/Course'


### PR DESCRIPTION
According to the Funnelback OpenAPI spec that we've written, Funnelback was supposed to return an object with a `numberOfMatches` integer and a `courses` array. But it actually returns a `numberOfMatches` integer and a `results` array. It seems to me that these ought to be aligned.