### PR TITLE
CFIN-244 Update numberOfMatches to be an integer

### DIFF
--- a/config/course-search.ftl
+++ b/config/course-search.ftl
@@ -9,7 +9,7 @@
     <#-- CALLBACK -->
         <#if RequestParameters.callback?has_content>${RequestParameters.callback}(</#if>
         {
-        "numberOfMatches": "${response.resultPacket.resultsSummary.fullyMatching?json_string}",
+        "numberOfMatches": ${response.resultPacket.resultsSummary.fullyMatching},
         "results":
         [
         <@s.Results>


### PR DESCRIPTION
This is a small change to make `numberOfMatches` an integer - this manifested as a PropTypes error when testing CFIN-244.