### PR TITLE
Add Natural Sciences path to the collection configuration

### DIFF
--- a/config/collection.cfg
+++ b/config/collection.cfg
@@ -8,7 +8,7 @@ collection_type=web
 crawler.non_html=
 crawler.overall_crawl_timeout=15
 crawler.reject_files=Z,asc,asf,asx,avi,bat,bib,bin,bmp,bz2,c,class,cpp,css,deb,dll,dmg,doc,docx,dvi,exe,fits,fts,gif,gz,h,ico,jar,java,jpeg,jpg,lzh,man,mid,mov,mp3,mp4,mpeg,mpg,o,old,pdf,pgp,png,ppm,ppt,pptx,qt,ra,ram,rpm,rtf,svg,swf,tar,tcl,tex,tgz,tif,tiff,vob,wav,wmv,wrl,xls,xlsx,xpm,zip
-include_patterns=www.york.ac.uk/study/undergraduate/courses/
+include_patterns=www.york.ac.uk/study/undergraduate/courses/,https://www.york.ac.uk/natural-sciences/undergraduate-study/
 query_processor_options=-stem=2 -SM=both -SF=[c,t,d,f,X,I,contentType,course.*] -rmc_sensitive=true -fmo=1 -qsup=SPEL/0.9+SYNS/0.5 -SQE=5 -cool.24=0 -daat=100000 -cool.1=0 -cool.2=0 -cool.32=1000 -cool.4=100
 service_name=University of York Courses
 ui.modern.form.course-search.content_type=application/json


### PR DESCRIPTION
The Natural Sciences course pages themselves do actually live under www.york.ac.uk/study/undergraduate/courses/, but there are only links to them from https://www.york.ac.uk/natural-sciences/undergraduate-study/. Our smeta_contentType=courses parameter works well here to prevent the non-course pages being returned.