### PR TITLE
CFIN-457 Update curation for Medicine course page

### DIFF
--- a/config/courses/curator.json
+++ b/config/courses/curator.json
@@ -463,4 +463,25 @@
     "type" : "PromoteUrls",
     "urlsToPromote" : [ "https://www.york.ac.uk/study/undergraduate/courses/bsc-interactive-media/", "https://www.york.ac.uk/study/undergraduate/courses/ba-theatre-writing-directing-performance/", "https://www.york.ac.uk/study/undergraduate/courses/ba-business-creative-industries/", "https://www.york.ac.uk/study/undergraduate/courses/ba-business-creative-industries/" ]
   } ]
+}, {
+  "created" : "2021-03-18T13:31:29.60701Z",
+  "lastModified" : "2021-03-18T13:31:29.615089Z",
+  "id" : "1842cc9f-6e7c-4072-84ed-371a488d2b07",
+  "name" : "Medicine search",
+  "label" : "DEFAULT",
+  "enabled" : true,
+  "trigger" : {
+    "type" : "And",
+    "triggers" : [ {
+      "type" : "Or",
+      "triggers" : [ {
+        "type" : "AllQueryWords",
+        "triggerWords" : [ "medicine" ]
+      } ]
+    } ]
+  },
+  "actions" : [ {
+    "type" : "PromoteUrls",
+    "urlsToPromote" : [ "https://www.hyms.ac.uk/medicine/mbbs-medicine" ]
+  } ]
 } ]


### PR DESCRIPTION
Following a change to the URL for the Medicine course entry so that it directs to the course page (https://www.hyms.ac.uk/medicine/mbbs-medicine) rather than the overarching Medicine page (https://www.hyms.ac.uk/medicine), it was noticed that the standard Medicine course was no longer returning first in the search results for "medicine".

Re-running tuning had no effect, so this is a suggested change to curate it to the top of the search for "medicine" (and it's associated synonyms).