### PR TITLE
CFIN-237 Add collection config for external-courses

### DIFF
--- a/config/external-courses/collection.cfg
+++ b/config/external-courses/collection.cfg
@@ -1,0 +1,10 @@
+admin_email=
+collection=$COLLECTION_NAME
+collection_type=custom
+data_report=false
+filter.classes=TikaFilterProvider,ExternalFilterProvider:JSoupProcessingFilterProvider:DocumentFixerFilterProvider:JSONToXML
+gather=custom-gather
+group.project_id=Courses
+query_processor_options=-stem=2 -SF=[.*]
+service_name=external-courses
+start_url=https://www.york.ac.uk/study/undergraduate/courses/hyms/


### PR DESCRIPTION
This PR just adds `collection.cfg` for the external-courses collection, this is already present and active in Funnelback